### PR TITLE
Fix ETA Formatting

### DIFF
--- a/qbittorrentui/windows/torrent_list.py
+++ b/qbittorrentui/windows/torrent_list.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import suppress
 from time import sleep, time
 
 import panwid
@@ -552,7 +553,10 @@ class TorrentRowColumns(uw.Columns):
 
         def format_eta(v):
             eta = pretty_time_delta(seconds=v) if v < SECS_INFINITY else INFINITY
-            return f"ETA {eta}".ljust(6)
+            # just use first unit from pretty time delta
+            with suppress(StopIteration):
+                eta = eta[:next(i for i, c in enumerate(eta) if not c.isnumeric())+1]
+            return f"ETA {eta.rjust(3)}"[:7]
 
         self.eta_w = val_cont(
             name="eta", raw_value=SECS_INFINITY, format_func=format_eta

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrentui",
-    version="0.3.1",
+    version="0.3.2",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={"": ["default.ini"]},
     include_package_data=True,


### PR DESCRIPTION
The ETA formatting was cutting off the unit when the time value was larger than one digit; so, `22h` would show as just `22`. Now, all ETA values are formatted for 3 characters; due to how formatting is handled, this value will be 3 characters at max.